### PR TITLE
线程的暂停建议优先使用TimeUnit类中的sleep()

### DIFF
--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/SegmentIDGenImpl.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/SegmentIDGenImpl.java
@@ -252,7 +252,7 @@ public class SegmentIDGenImpl implements IDGen {
             roll += 1;
             if(roll > 10000) {
                 try {
-                    Thread.currentThread().sleep(10);
+                    TimeUnit.MILLISECONDS.sleep(10);
                     break;
                 } catch (InterruptedException e) {
                     logger.warn("Thread {} Interrupted",Thread.currentThread().getName());


### PR DESCRIPTION
建议Thread.sleep()最好使用现代化写法TimeUnit.sleep()方法来代替，TimeUnit枚举成员的sleep方法更优雅，它可以提高代码的可读性并且不会带来性能损失。
例如：TimeUnit.MILLISECONDS.sleep(10) 意思是，休息10毫秒个时间单位。