### PR TITLE
修复getIp在linux下获取异常的问题,并支持多网卡下的ip获取

### DIFF
--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/common/Utils.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/common/Utils.java
@@ -3,19 +3,73 @@ package com.sankuai.inf.leaf.common;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 public class Utils {
     private static final Logger logger = LoggerFactory.getLogger(Utils.class);
+
     public static String getIp() {
         String ip;
         try {
-            InetAddress addr = InetAddress.getLocalHost();
-            ip = addr.getHostAddress();
-        } catch(Exception ex) {
+            List<String> ipList = getHostAddress(null);
+            // default the first
+            ip = (!ipList.isEmpty()) ? ipList.get(0) : "";
+        } catch (Exception ex) {
             ip = "";
             logger.warn("Utils get IP warn", ex);
         }
         return ip;
+    }
+
+    public static String getIp(String interfaceName) {
+        String ip;
+        interfaceName = interfaceName.trim();
+        try {
+            List<String> ipList = getHostAddress(interfaceName);
+            ip = (!ipList.isEmpty()) ? ipList.get(0) : "";
+        } catch (Exception ex) {
+            ip = "";
+            logger.warn("Utils get IP warn", ex);
+        }
+        return ip;
+    }
+
+    /**
+     * 获取已激活网卡的IP地址
+     *
+     * @param interfaceName 可指定网卡名称,null则获取全部
+     * @return List<String>
+     */
+    private static List<String> getHostAddress(String interfaceName) throws SocketException {
+        List<String> ipList = new ArrayList<String>(5);
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface ni = interfaces.nextElement();
+            Enumeration<InetAddress> allAddress = ni.getInetAddresses();
+            while (allAddress.hasMoreElements()) {
+                InetAddress address = allAddress.nextElement();
+                if (address.isLoopbackAddress()) {
+                    // skip the loopback addr
+                    continue;
+                }
+                if (address instanceof Inet6Address) {
+                    // skip the IPv6 addr
+                    continue;
+                }
+                String hostAddress = address.getHostAddress();
+                if (null == interfaceName) {
+                    ipList.add(hostAddress);
+                } else if (interfaceName.equals(ni.getDisplayName())) {
+                    ipList.add(hostAddress);
+                }
+            }
+        }
+        return ipList;
     }
 }


### PR DESCRIPTION
错误的ip会导致zookeeper的相关连接频繁报错
1、解决了linux下由于host和hostname的绑定而导致InetAddress.getLocalHost().getHostAddress()获取到127.0.0.1的问题
2、增加了多网卡下的ip获取，指定网卡名（linux下如eth0，windows下如Realtek PCIe GBE Family Controller）即可，需要时可单独放到leaf.properties中配置