### PR TITLE
一点性能小优化

### DIFF
--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/model/SegmentBuffer.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/model/SegmentBuffer.java
@@ -52,7 +52,7 @@ public class SegmentBuffer {
     }
 
     public int nextPos() {
-        return (currentPos + 1) % 2;
+        return (currentPos + 1) & 1;
     }
 
     public void switchPos() {


### PR DESCRIPTION
美团的同学:
你们好！这个PR主要是针对https://github.com/Meituan-Dianping/Leaf/issues/72 进行了进一步的优化，感谢你们抽出时间进行查阅。

SegmentIDGenImpl.updateCacheFromDb()方法
原方案工作流程:
       1.遍历cacheTags，将dbTags的副本insertTagsSet中存在的元素移除，使得insertTagsSet只有db新增的tag
     2.遍历insertTagsSet，将这些新增的元素添加到cache中
       3.遍历dbTags，将cacheTags的副本removeTagsSet中存在的元素移除，使得removeTagsSet只有cache中过期的tag
       4.遍历removeTagsSet，将过期的元素移除cache
       这种方案需要经历四次循环，使用两个HashSet分别存储db中新增的tag，cache中过期的tag，
       并且为了筛选出新增的tag，过期的tag，对每个现在使用的tag有两次删除操作，
      
原有方案代码如下：
```
            List<String> dbTags = dao.getAllTags();
            if (dbTags == null || dbTags.isEmpty()) {
                return;
            }
            List<String> cacheTags = new ArrayList<String>(cache.keySet());
            Set<String> insertTagsSet = new HashSet<>(dbTags);
            Set<String> removeTagsSet = new HashSet<>(cacheTags);
            //db中新加的tags灌进cache
            for(int i = 0; i < cacheTags.size(); i++){
                String tmp = cacheTags.get(i);
                if(insertTagsSet.contains(tmp)){
                    insertTagsSet.remove(tmp);
                }
            }
            for (String tag : insertTagsSet) {
                SegmentBuffer buffer = new SegmentBuffer();
                buffer.setKey(tag);
                Segment segment = buffer.getCurrent();
                segment.setValue(new AtomicLong(0));
                segment.setMax(0);
                segment.setStep(0);
                cache.put(tag, buffer);
                logger.info("Add tag {} from db to IdCache, SegmentBuffer {}", tag, buffer);
            }
            //cache中已失效的tags从cache删除
            for(int i = 0; i < dbTags.size(); i++){
                String tmp = dbTags.get(i);
                if(removeTagsSet.contains(tmp)){
                    removeTagsSet.remove(tmp);
                }
            }
            for (String tag : removeTagsSet) {
                cache.remove(tag);
                logger.info("Remove tag {} from IdCache", tag);
            }
```

实际上我们并不需要这些中间过程，现方案工作流程：
       只需要遍历dbTags，判断cache中是否存在这个key，不存在就是新增元素，进行新增。
       遍历cacheTags，判断dbSet中是否存在这个key，不存在就是过期元素，进行删除。

现有方案代码：
```
            List<String> dbTags = dao.getAllTags();
            if (dbTags == null || dbTags.isEmpty()) {
                return;
            }
            //将dbTags中新加的tag添加cache，通过遍历dbTags，判断是否在cache中存在，不存在就添加到cache
            for (String dbTag : dbTags) {
                if (cache.containsKey(dbTag)==false) {
                    SegmentBuffer buffer = new SegmentBuffer();
                    buffer.setKey(dbTag);
                    Segment segment = buffer.getCurrent();
                    segment.setValue(new AtomicLong(0));
                    segment.setMax(0);
                    segment.setStep(0);
                    cache.put(dbTag, buffer);
                    logger.info("Add tag {} from db to IdCache, SegmentBuffer {}", dbTag, buffer);
                }
            }
            List<String> cacheTags = new ArrayList<String>(cache.keySet());
            Set<String>  dbTagSet     = new HashSet<>(dbTags);
            //将cache中已失效的tag从cache删除，通过遍历cacheTags，判断是否在dbTagSet中存在，不存在说明过期，直接删除
            for (String cacheTag : cacheTags) {
                if (dbTagSet.contains(cacheTag) == false) {
                    cache.remove(cacheTag);
                    logger.info("Remove tag {} from IdCache", cacheTag);
                }
            }
```

两个方案对比：
* 空间复杂度
相比原方案需要使用两个HashSet，这种方案的只需要使用一个hashSet，空间复杂度会低一些。
* 时间复杂度
总遍历次数会比原来的少，时间复杂度更低，因为判断是新增，过期的情况就直接处理了，不需要后续再单独遍历，
而且不需要对cache和dbtag的交集进行删除操作，因为原来方案为了获得新增的元素，是将dbSet的副本中现有元素进行删除得到。
* 代码可读性
原方案是4个for循环，总共35行代码，现方案是2个for循环，总共25行代码，更加简洁易懂。

还有一个更新是针对这个issue https://github.com/Meituan-Dianping/Leaf/issues/88 ，使用位运算&来代替取模运算%，执行效率更高。
原代码：
```
public int nextPos() {
        return (currentPos + 1) % 2;
}
```
现代码：
```
public int nextPos() {
        return (currentPos + 1) & 1;
}
```