### PR TITLE
segment获取ID，添加批量方式

### DIFF
--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/IDGen.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/IDGen.java
@@ -3,6 +3,10 @@ package com.sankuai.inf.leaf;
 import com.sankuai.inf.leaf.common.Result;
 
 public interface IDGen {
+
     Result get(String key);
+
     boolean init();
+
+    Result getBatch(String key, Long size);
 }

--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/common/Result.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/common/Result.java
@@ -1,15 +1,22 @@
 package com.sankuai.inf.leaf.common;
 
 public class Result {
+
     private long id;
+    private long size = 1;
     private Status status;
 
     public Result() {
-
     }
+
     public Result(long id, Status status) {
         this.id = id;
         this.status = status;
+    }
+
+    public Result(long id, long size, Status status) {
+        this(id, status);
+        this.size = size;
     }
 
     public long getId() {
@@ -18,6 +25,14 @@ public class Result {
 
     public void setId(long id) {
         this.id = id;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
     }
 
     public Status getStatus() {

--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/common/ZeroIDGen.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/common/ZeroIDGen.java
@@ -12,4 +12,9 @@ public class ZeroIDGen implements IDGen {
     public boolean init() {
         return true;
     }
+
+    @Override
+    public Result getBatch(String key, Long size) {
+        return null;
+    }
 }

--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/SegmentIDGenImpl.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/segment/SegmentIDGenImpl.java
@@ -236,9 +236,9 @@ public class SegmentIDGenImpl implements IDGen {
                         }
                     });
                 }
-                long value = segment.getValue().getAndAdd(size);
+                long value = segment.getValue().addAndGet(size);
                 if (value < segment.getMax()) {
-                    return new Result(value, size, Status.SUCCESS);
+                    return new Result(value - size, size, Status.SUCCESS);
                 }
             } finally {
                 buffer.rLock().unlock();
@@ -247,9 +247,9 @@ public class SegmentIDGenImpl implements IDGen {
             buffer.wLock().lock();
             try {
                 final Segment segment = buffer.getCurrent();
-                long value = segment.getValue().getAndAdd(size);
+                long value = segment.getValue().addAndGet(size);
                 if (value < segment.getMax()) {
-                    return new Result(value, size, Status.SUCCESS);
+                    return new Result(value - size, size, Status.SUCCESS);
                 }
                 if (buffer.isNextReady()) {
                     buffer.switchPos();

--- a/leaf-core/src/main/java/com/sankuai/inf/leaf/snowflake/SnowflakeIDGenImpl.java
+++ b/leaf-core/src/main/java/com/sankuai/inf/leaf/snowflake/SnowflakeIDGenImpl.java
@@ -17,6 +17,11 @@ public class SnowflakeIDGenImpl implements IDGen {
         return true;
     }
 
+    @Override
+    public Result getBatch(String key, Long size) {
+        return null;
+    }
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeIDGenImpl.class);
 
     private final long twepoch;
@@ -32,7 +37,7 @@ public class SnowflakeIDGenImpl implements IDGen {
     private static final Random RANDOM = new Random();
 
     public SnowflakeIDGenImpl(String zkAddress, int port) {
-        //Thu Nov 04 2010 09:42:54 GMT+0800 (中国标准时间) 
+        //Thu Nov 04 2010 09:42:54 GMT+0800 (中国标准时间)
         this(zkAddress, port, 1288834974657L);
     }
 

--- a/leaf-server/src/main/java/com/sankuai/inf/leaf/server/controller/LeafController.java
+++ b/leaf-server/src/main/java/com/sankuai/inf/leaf/server/controller/LeafController.java
@@ -27,6 +27,11 @@ public class LeafController {
         return get(key, segmentService.getId(key));
     }
 
+    @RequestMapping(value = "/api/segment/get/{key}/{size}")
+    public String getSegmentIdBatch(@PathVariable("key") String key,@PathVariable("size") Long size) {
+        return get(key, segmentService.getIdBatch(key, size));
+    }
+
     @RequestMapping(value = "/api/snowflake/get/{key}")
     public String getSnowflakeId(@PathVariable("key") String key) {
         return get(key, snowflakeService.getId(key));
@@ -40,6 +45,9 @@ public class LeafController {
         result = id;
         if (result.getStatus().equals(Status.EXCEPTION)) {
             throw new LeafServerException(result.toString());
+        }
+        if (result.getSize() > 1) {
+            return (result.getId() + ":" + result.getSize());
         }
         return String.valueOf(result.getId());
     }

--- a/leaf-server/src/main/java/com/sankuai/inf/leaf/server/service/SegmentService.java
+++ b/leaf-server/src/main/java/com/sankuai/inf/leaf/server/service/SegmentService.java
@@ -56,6 +56,10 @@ public class SegmentService {
         return idGen.get(key);
     }
 
+    public Result getIdBatch(String key, Long size) {
+        return idGen.getBatch(key, size);
+    }
+
     public SegmentIDGenImpl getIdGen() {
         if (idGen instanceof SegmentIDGenImpl) {
             return (SegmentIDGenImpl) idGen;


### PR DESCRIPTION
适用于批量生成数据主键的情景

不足之处在于，比如步长为10000，每次获取1000，则最大损失999个位置

如果步长10000，每次获取20，则损失非常小，根据场景取舍

