### PR TITLE
fix-support-mysql8

### DIFF
--- a/leaf-server/src/main/java/com/sankuai/inf/leaf/server/Constants.java
+++ b/leaf-server/src/main/java/com/sankuai/inf/leaf/server/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
     public static final String LEAF_JDBC_URL = "leaf.jdbc.url";
     public static final String LEAF_JDBC_USERNAME = "leaf.jdbc.username";
     public static final String LEAF_JDBC_PASSWORD = "leaf.jdbc.password";
+    public static final String LEAF_JDBC_DRIVER_CLASS_NAME = "leaf.jdbc.driverClassName";
 
     public static final String LEAF_SNOWFLAKE_ENABLE = "leaf.snowflake.enable";
     public static final String LEAF_SNOWFLAKE_PORT = "leaf.snowflake.port";

--- a/leaf-server/src/main/java/com/sankuai/inf/leaf/server/service/SegmentService.java
+++ b/leaf-server/src/main/java/com/sankuai/inf/leaf/server/service/SegmentService.java
@@ -33,6 +33,7 @@ public class SegmentService {
             dataSource.setUrl(properties.getProperty(Constants.LEAF_JDBC_URL));
             dataSource.setUsername(properties.getProperty(Constants.LEAF_JDBC_USERNAME));
             dataSource.setPassword(properties.getProperty(Constants.LEAF_JDBC_PASSWORD));
+            dataSource.setDriverClassName(properties.getProperty(Constants.LEAF_JDBC_DRIVER_CLASS_NAME));
             dataSource.init();
 
             // Config Dao


### PR DESCRIPTION
当使用mysql8的时候，需要指定新的数据库驱动类名称com.mysql.cj.jdbc.Driver ！！！这里需要加入新的配置key，让其加载新的驱动类,而不是使用Druid里面默认的驱动类。