### PR TITLE
fix(sec): upgrade com.alibaba:druid to 1.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <perf4j.version>0.9.16</perf4j.version>
         <curator.version>2.6.0</curator.version>
         <slf4j.version>1.7.2</slf4j.version>
-        <druid.version>1.0.18</druid.version>
+        <druid.version>1.2.4</druid.version>
         <jackson-databind.version>2.9.6</jackson-databind.version>
         <mysql-connector-java.version>5.1.38</mysql-connector-java.version>
         <commons-io.version>2.4</commons-io.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:druid 1.0.18
- [CVE-2021-33800](https://www.oscs1024.com/hd/CVE-2021-33800)


### What did I do？
Upgrade com.alibaba:druid from 1.0.18 to 1.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS